### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/verify_all.yml
+++ b/.github/workflows/verify_all.yml
@@ -1,4 +1,6 @@
 name: Verify All (Typecheck, Lint, Test)
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/able-wong/redact-pii-core/security/code-scanning/1](https://github.com/able-wong/redact-pii-core/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will specify the least privileges required for the workflow to function. Since the workflow only checks out the repository and runs Node.js commands, it only needs `contents: read` permissions. This ensures that the workflow can read the repository contents but cannot modify them or perform other actions requiring elevated permissions.

The `permissions` block will be added immediately after the `name` field at the top of the file.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
